### PR TITLE
chore(ci): refine deploy triggers

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,6 @@ name: Deploy Static Site to GitHub Pages
 on:
   workflow_run:
     workflows:
-      - "Update ADS Publications List"
       - "Generate Figure Data"
       - "Update ADS Citation Metrics"
       - "Update NASA ADS Citations Plot and Data"


### PR DESCRIPTION
## Summary
- remove Update ADS Publications List from deploy workflow triggers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Next.js asked for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6892e20b724c832c8d41712039f0384e