### PR TITLE
chore(workflows): restrict push workflows to main branch

### DIFF
--- a/.github/workflows/convert-pdfs.yml
+++ b/.github/workflows/convert-pdfs.yml
@@ -2,6 +2,7 @@ name: Convert PDFs to SVG
 
 on:
   push:
+    branches: [main]
     paths:
       - 'public/paper-figures/pdfs/**'
 

--- a/.github/workflows/generate-figure-data.yml
+++ b/.github/workflows/generate-figure-data.yml
@@ -2,6 +2,7 @@ name: Generate Figure Data
 
 on:
   push:
+    branches: [main]
     paths:
       - 'public/data/ads_publications.json'
       - 'public/paper-figures/captions-bibcodes.json'


### PR DESCRIPTION
## Summary
- ensure convert-pdfs and generate-figure-data workflows only run on main branch

## Testing
- `npm run lint` *(fails: interactive config prompt)*
- `npm run typecheck` *(fails: TS2322 errors in icon components)*

------
https://chatgpt.com/codex/tasks/task_e_6892e20a2358832c8a6a2c686952be61