### PR TITLE
chore(ci): add concurrency block to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,6 +11,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     if: github.event.workflow_run.conclusion == 'success'


### PR DESCRIPTION
## Summary
- prevent overlapping deploy runs with a concurrency group

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*
- `npm run typecheck` *(fails: Type 'HTMLImageElement | null' is not assignable to type 'SVGSVGElement | null')*

------
https://chatgpt.com/codex/tasks/task_e_6892e20e66c8832c82c78273604e0003